### PR TITLE
fix: position is lost when toggling window

### DIFF
--- a/lua/floating-help/init.lua
+++ b/lua/floating-help/init.lua
@@ -69,11 +69,16 @@ function FloatingHelp.open(...)
   end
 end
 
+local buffer_position = { 0, 0 }
 function FloatingHelp.toggle(...)
   if FloatingHelp.is_open() then
+    buffer_position = vim.api.nvim_win_get_cursor(0)
     FloatingHelp.close()
   else
     FloatingHelp.open(...)
+    vim.schedule(function()
+      vim.api.nvim_win_set_cursor(0, buffer_position)
+    end)
   end
 end
 

--- a/lua/floating-help/view.lua
+++ b/lua/floating-help/view.lua
@@ -165,6 +165,11 @@ function View:setup(opts)
   local query = opts.query or self.query
   local query_type = opts.type or self.query_type
 
+  -- keep cursor at the center
+  vim.schedule(function()
+    vim.opt_local.scrolloff = 999
+  end)
+
   -- if not ok, opts were incomplete
   if ok then
     if query_type == 'help' then


### PR DESCRIPTION
Keep track of cursor position so that the window contents gets back to where it was before hiding. 