### PR TITLE
feat: command help autocompletion

### DIFF
--- a/plugin/floating-help.lua
+++ b/plugin/floating-help.lua
@@ -1,17 +1,40 @@
 local ucmd = vim.api.nvim_create_user_command
 local fh = require('floating-help')
 
-ucmd('FloatingHelp', function(opts) fh.open(unpack(opts.fargs)) end, {
+--- Complete the ArgLead with a custom completion list.
+--- The list does not have to searched through vim will do that for you.
+--- @param ArgLead string The leading portion of the argument currently being completed on.
+--- @param CmdLine string The entire command line.
+--- @param CursorPos number The cursor position in it (byte index).
+--- @return table
+local function completion(ArgLead, CmdLine, CursorPos)
+  -- TODO: Make completions based on the ArgLead and return predictions as a list.
+  -- Currently is a no op.
+  return {ArgLead}
+end
+
+ucmd('FloatingHelp', function(opts)
+  fh.open(unpack(opts.fargs))
+end, {
   nargs = '*',
-  complete = function(_, lines)
-    --TODO
-  end,
+
+  --- For reference the values of the `complete` attribute can be found in the help:
+  --- `:h :command-completion`
+  complete = 'help',
+
+  --- For reference when the `complete` attribute is a function, can be found in the help:
+  --- `:h :command-completion-customlist`
+  -- complete = completion
 })
 ucmd('FloatingHelpToggle', function(opts) fh.toggle(unpack(opts.fargs)) end, {
   nargs = '*',
-  complete = function(_, lines)
-    --TODO
-  end,
+
+  --- For reference the values of the `complete` attribute can be found in the help:
+  --- `:h :command-completion`
+  complete = 'help',
+
+  --- For reference when the `complete` attribute is a function, can be found in the help:
+  --- `:h :command-completion-customlist`
+  -- complete = completion
 })
 ucmd('FloatingHelpClose', function() fh.close() end, { nargs = 0 })
-


### PR DESCRIPTION
## Summary

When this repo overrides the `:h` to `:FloatingHelp` we loose the ability to auto complete the help pages.
This PR seeks to add those and add a bit of in code documentation on how to add custom completion logic.

If this aligns with your views of the plugin of course.

## Changes

- Set default `complete` value to help for the user commands.
- Added in code documentation and no-op clause as option for the `complete` user commands.

<details><summary>Example</summary>
<p>

![floating-help-autocomplete](https://github.com/Tyler-Barham/floating-help.nvim/assets/6429179/5527c25f-3a8a-4ee0-833b-2d3e909a7179)

</p>
</details>